### PR TITLE
Added toNextFull method to TimeUtil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 -   Deprecated `PowerDensity` (will be replaced by `Irradiation`) & SI conform usage of `Irradiation` and `EnergyDensity` ([#54](https://github.com/ie3-institute/PowerSystemUtils/issues/54))
+-   Minor addition to `TimeUtil`
 
 ## [1.4]
 

--- a/src/main/java/edu/ie3/util/TimeUtil.java
+++ b/src/main/java/edu/ie3/util/TimeUtil.java
@@ -129,4 +129,18 @@ public class TimeUtil {
       ZonedDateTime startDateTime, ZonedDateTime endDateTime, ChronoUnit unit) {
     return unit.between(startDateTime, endDateTime);
   }
+
+  /**
+   * Moves the given zoned date time to the next full unit (e.g. hour)
+   *
+   * @param zdt Zoned date time to alter
+   * @param chronoUnit Next full time unit
+   * @return Next full chrono unit, if it does not meet yet
+   */
+  public static ZonedDateTime toNextFull(ZonedDateTime zdt, ChronoUnit chronoUnit) {
+    ZonedDateTime truncatedToFullHour =
+        zdt.truncatedTo(chronoUnit); // Truncate all minutes and less
+    if (zdt.isAfter(truncatedToFullHour)) return truncatedToFullHour.plus(1L, chronoUnit);
+    return zdt;
+  }
 }

--- a/src/test/groovy/edu/ie3/util/TimeUtilTest.groovy
+++ b/src/test/groovy/edu/ie3/util/TimeUtilTest.groovy
@@ -9,6 +9,7 @@ import spock.lang.Specification
 
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 
 
 class TimeUtilTest extends Specification {
@@ -162,6 +163,23 @@ class TimeUtilTest extends Specification {
 		"2020-04-22 23:15:00" || 93
 		"2020-04-22 23:30:00" || 94
 		"2020-04-22 23:45:00" || 95
+	}
+
+	def "A TimeUtil is able to round to the next full chrono unit"() {
+		expect:
+		def time = TimeUtil.withDefaults.toZonedDateTime(timeStamp)
+		def expectedTime = TimeUtil.withDefaults.toZonedDateTime(expected)
+		TimeUtil.toNextFull(time, chronoUnit) == expectedTime
+
+		where:
+		timeStamp             || chronoUnit         || expected
+		"2020-04-21 23:59:00" || ChronoUnit.HOURS   || "2020-04-22 00:00:00"
+		"2020-04-22 00:00:00" || ChronoUnit.HOURS   || "2020-04-22 00:00:00"
+		"2020-04-22 00:01:00" || ChronoUnit.HOURS   || "2020-04-22 01:00:00"
+		"2020-04-22 00:59:50" || ChronoUnit.HOURS   || "2020-04-22 01:00:00"
+		"2020-04-22 00:59:50" || ChronoUnit.HOURS   || "2020-04-22 01:00:00"
+		"2020-04-22 01:00:00" || ChronoUnit.DAYS    || "2020-04-23 00:00:00"
+		"2020-04-21 23:59:01" || ChronoUnit.MINUTES || "2020-04-22 00:00:00"
 	}
 }
 


### PR DESCRIPTION
Move method `toNextFull` from SIMONA's `SampleWeatherSource` to TimeUtils.

The other methods listed in the #56 issue have not been transferred.