### PR TITLE
Added Bao and Staudt to Reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,10 @@ updates:
   open-pull-requests-limit: 10
   reviewers:
   - t-ober
-  - sensarmad
+  - staudtMarius
   - sebastian-peter
   - danielfeismann
+  - jo-bao
   ignore:
   - dependency-name: org.scalatest:scalatest_2.13
     versions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased/Snapshot]
 
+### Changed
+- Added Bao and Staudt to the list of reviewers [#510](https://github.com/ie3-institute/PowerSystemUtils/issues/510)
+
 ## [2.2.1]
 
 ### Changed


### PR DESCRIPTION
This pull request includes updates to the `.github/dependabot.yml` file and the `CHANGELOG.md` file to reflect changes in the list of reviewers.

Updates to reviewer assignments:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L11-R14): Replaced `sensarmad` with `staudtMarius` and added `jo-bao` to the list of reviewers.

Documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R11): Added an entry to the changelog noting the addition of Bao and Staudt to the list of reviewers.