### PR TITLE
Auto Review and update Restriction

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,9 +6,28 @@ permissions:
   pull-requests: write
 
 jobs:
-  dependabot:
+  approve:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'ie3-institute/PowerSystemUtils'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto approval of PR
+        if: ${{ !contains(steps.meta.outputs.new-version, 'snap') }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+  merge:
+    needs: approve
+    runs-on: ubuntu-latest
+    if:  ${{ needs.approve.result == 'success' && !contains((steps.approve.outputs.new-version), 'snap') }}
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased/Snapshot]
+### Fixed
+- Added auto-approval to dependabot workflow and restrictions to updates [#551](https://github.com/ie3-institute/PowerSystemUtils/issues/551)
 
 ## [3.0.0]
 


### PR DESCRIPTION
Closes #551 

This pull request introduces an enhancement to the Dependabot workflow by adding an auto-approval step and restricting updates based on specific conditions. Additionally, the `CHANGELOG.md` file has been updated to document these changes.

### Workflow Enhancements:
* [`.github/workflows/dependabot-auto-merge.yml`](diffhunk://#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1L9-R30): Replaced the `dependabot` job with separate `approve` and `merge` jobs. The `approve` job auto-approves Dependabot pull requests if they meet certain conditions, and the `merge` job ensures that only approved pull requests without "snap" versions are merged.

### Documentation Updates:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R9): Added a "Fixed" entry under the "Unreleased/Snapshot" section to document the addition of auto-approval and update restrictions in the Dependabot workflow.