### PR TITLE
Included Sonar CI step for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
         run: ./gradlew scaladoc
 
       - name: SonarQube
-        if: ${{ !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.ref_name, 'dependabot/') }}
         run: |
           ./gradlew sonar \
           -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }} \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased/Snapshot]
 
+### Changed
+- Included SonarQube step for Dependabot PRs [#575](https://github.com/ie3-institute/PowerSystemUtils/issues/575)
+
 ## [3.1.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased/Snapshot]
 
 ### Changed
-- Included SonarQube step for Dependabot PRs [#575](https://github.com/ie3-institute/PowerSystemUtils/issues/575)
+- Reincluded SonarQube step for Dependabot PRs [#575](https://github.com/ie3-institute/PowerSystemUtils/issues/575)
 
 ## [3.1.0]
 


### PR DESCRIPTION
Closes #575 

This pull request makes adjustments to the CI pipeline and updates the changelog to reflect the changes. The most significant update is enabling the SonarQube step for Dependabot pull requests.

### CI pipeline updates:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL81): Removed the condition that excluded Dependabot branches from running the SonarQube step, allowing SonarQube analysis for Dependabot pull requests.

### Documentation updates:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R11): Added a note under the "Changed" section to document the inclusion of SonarQube analysis for Dependabot pull requests, referencing issue #575.